### PR TITLE
Vectorize radial profile calculation

### DIFF
--- a/pywoc/radial_profile.py
+++ b/pywoc/radial_profile.py
@@ -6,26 +6,69 @@ from astropy.convolution import Gaussian2DKernel
 
 __all__ = ['radial_profile']
 
-def radial_profile(data, mask, center, rmin, rmax,width, method='median'):
-    y,x = np.indices((data.shape)) # first determine radii of all pixels
-    r = np.sqrt((x-center[0])**2+(y-center[1])**2)
-    sr = r.flat
-    sim = data.flat  
-    msk = mask.flat
-    msk[sim==-np.inf]=0
-    msk[sim==np.inf]=0
-    rbins=np.arange(rmin,rmax,width)
-    nbins=len(rbins)
-    array=np.zeros(np.shape(rbins[:-1]))
-    
-    n=0
-    for rr in rbins[:-1]:
-        inds=np.where((sr>=rr) & (sr<=rr+width) & (sim==sim) & (msk==1))
-        if method=='median':
-            array[n]=np.median(sim[np.squeeze(inds)]) 
-        if(method=='mean'):
-            array[n]=np.mean(sim[np.squeeze(inds)])    
-        n=n+1
-        #print(len(np.squeeze(inds)))
-    return rbins[:-1]+0.5*width, array
+def radial_profile(data, mask, center, rmin, rmax, width, method='median'):
+    """Compute the radial profile of *data* around *center*.
+
+    Parameters
+    ----------
+    data : ndarray
+        2-D map whose radial statistics are computed.
+    mask : ndarray
+        Boolean mask array where valid pixels are 1.
+    center : tuple
+        ``(x, y)`` coordinates of the profile centre.
+    rmin, rmax : float
+        Minimum and maximum radius to consider.
+    width : float
+        Bin width.
+    method : {"median", "mean"}, optional
+        Statistic to compute for each radial bin.
+
+    Returns
+    -------
+    r : ndarray
+        Radii at the centre of each bin.
+    array : ndarray
+        Computed statistic for each radial bin.
+    """
+
+    # Determine radius of every pixel relative to the centre
+    y, x = np.indices(data.shape)
+    r = np.sqrt((x - center[0]) ** 2 + (y - center[1]) ** 2)
+
+    sim = data.ravel()
+    sr = r.ravel()
+    msk = mask.ravel().copy()
+
+    # Exclude invalid values
+    msk[(sim == -np.inf) | (sim == np.inf)] = 0
+    valid = (msk == 1) & np.isfinite(sim)
+
+    sim = sim[valid]
+    sr = sr[valid]
+
+    rbins = np.arange(rmin, rmax, width)
+    nbins = len(rbins[:-1])
+
+    if method not in ("median", "mean"):
+        raise ValueError("method must be 'median' or 'mean'")
+
+    bin_low = rbins[:-1]
+    bin_high = bin_low + width
+
+    sr_col = sr[:, None]
+    cond = (sr_col >= bin_low) & (sr_col <= bin_high)
+
+    if method == "mean":
+        counts = cond.sum(axis=0)
+        sums = (sim[:, None] * cond).sum(axis=0)
+        with np.errstate(invalid="ignore"):
+            array = sums / counts
+    else:  # median
+        array = np.array([
+            np.median(sim[cond[:, i]]) if np.any(cond[:, i]) else np.nan
+            for i in range(nbins)
+        ])
+
+    return rbins[:-1] + 0.5 * width, array
 

--- a/tests/test_woc.py
+++ b/tests/test_woc.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import importlib.util
+import numpy as np
+from astropy.convolution import convolve, Gaussian2DKernel
+
+# disable numba JIT to avoid requiring numba for test execution
+os.environ['NUMBA_DISABLE_JIT'] = '1'
+
+# Load local modules explicitly to avoid pulling the site package version
+base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+
+spec_radial = importlib.util.spec_from_file_location(
+    'pywoc.radial_profile', os.path.join(base_path, 'pywoc', 'radial_profile.py')
+)
+radial_mod = importlib.util.module_from_spec(spec_radial)
+sys.modules[spec_radial.name] = radial_mod
+spec_radial.loader.exec_module(radial_mod)
+
+spec_woc = importlib.util.spec_from_file_location(
+    'pywoc.woc', os.path.join(base_path, 'pywoc', 'woc.py')
+)
+woc_mod = importlib.util.module_from_spec(spec_woc)
+sys.modules[spec_woc.name] = woc_mod
+spec_woc.loader.exec_module(woc_mod)
+
+woc = woc_mod.woc
+
+
+def generate_maps():
+    """Generate data similar to nb/tutorial.py."""
+    np.random.seed(123456)
+    x, y = np.random.multivariate_normal((500, 500), ((8600, -10200), (4000, 6600)), 200000, check_valid='ignore').T
+    a, _, _ = np.histogram2d(x, y, 100, range=((200, 800), (200, 800)))
+    kernel = Gaussian2DKernel(10, mode='linear_interp')
+    dm_model = convolve(a, kernel, boundary='extend', nan_treatment='interpolate', preserve_nan=False)
+
+    x, y = np.random.multivariate_normal((450, 550), ((8600, -1200), (4000, 6600)), 200000, check_valid='ignore').T
+    a, _, _ = np.histogram2d(x, y, 100, range=((200, 800), (200, 800)))
+    kernel = Gaussian2DKernel(10, mode='linear_interp')
+    icl_model = convolve(a, kernel, boundary='extend', nan_treatment='interpolate', preserve_nan=False)
+    return dm_model, icl_model
+
+
+def test_woc_value():
+    dm, icl = generate_maps()
+    value = woc(dm, icl, [10, 20, 30], plot=False, rbins=20)
+    assert np.isclose(value, 0.4768612628717713, rtol=1e-5)


### PR DESCRIPTION
## Summary
- refactor `radial_profile` to compute bin statistics with vectorized numpy operations
- keep behaviour consistent with previous implementation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a287cd7c832cb50ad14ad1144474